### PR TITLE
Fixed String() method on Struct to take into account parent validity bitmap for fields

### DIFF
--- a/go/arrow/array/struct.go
+++ b/go/arrow/array/struct.go
@@ -47,11 +47,29 @@ func (a *Struct) Field(i int) Interface { return a.fields[i] }
 func (a *Struct) String() string {
 	o := new(strings.Builder)
 	o.WriteString("{")
+	// for i, v := range a.fields {
+	// 	if i > 0 {
+	// 		o.WriteString(" ")
+	// 	}
+	// 	fmt.Fprintf(o, "%v", v)
+	// 	switch {
+	// 	case a.IsNull(i):
+	// 		o.WriteString("(null)")
+	// 	default:
+	// 		fmt.Fprintf(o, "%v", v)
+	// 	}
+	// }
+
 	for i, v := range a.fields {
 		if i > 0 {
 			o.WriteString(" ")
 		}
-		fmt.Fprintf(o, "%v", v)
+		switch {
+		case a.IsNull(i):
+			o.WriteString("(null)")
+		default:
+			fmt.Fprintf(o, "%v", v)
+		}
 	}
 	o.WriteString("}")
 	return o.String()

--- a/go/arrow/array/struct.go
+++ b/go/arrow/array/struct.go
@@ -17,6 +17,7 @@
 package array
 
 import (
+	"bytes"
 	"fmt"
 	"strings"
 	"sync/atomic"
@@ -47,32 +48,47 @@ func (a *Struct) Field(i int) Interface { return a.fields[i] }
 func (a *Struct) String() string {
 	o := new(strings.Builder)
 	o.WriteString("{")
-	// for i, v := range a.fields {
-	// 	if i > 0 {
-	// 		o.WriteString(" ")
-	// 	}
-	// 	fmt.Fprintf(o, "%v", v)
-	// 	switch {
-	// 	case a.IsNull(i):
-	// 		o.WriteString("(null)")
-	// 	default:
-	// 		fmt.Fprintf(o, "%v", v)
-	// 	}
-	// }
 
+	structBitmap := a.NullBitmapBytes()
 	for i, v := range a.fields {
 		if i > 0 {
 			o.WriteString(" ")
 		}
-		switch {
-		case a.IsNull(i):
-			o.WriteString("(null)")
-		default:
-			fmt.Fprintf(o, "%v", v)
+		if !bytes.Equal(structBitmap, v.NullBitmapBytes()) {
+			masked := newStructFieldWithParentValidityMask(a, i)
+			fmt.Fprintf(o, "%v", masked)
+			masked.Release()
+			continue
 		}
+		fmt.Fprintf(o, "%v", v)
 	}
 	o.WriteString("}")
 	return o.String()
+}
+
+// newStructFieldWithParentValidityMask returns the Interface at fieldIndex
+// with a nullBitmapBytes adjusted according on the parent struct nullBitmapBytes.
+// From the docs:
+//   "When reading the struct array the parent validity bitmap takes priority."
+func newStructFieldWithParentValidityMask(a *Struct, fieldIndex int) Interface {
+	field := a.Field(fieldIndex)
+	nullBitmapBytes := field.NullBitmapBytes()
+	maskedNullBitmapBytes := make([]byte, len(nullBitmapBytes))
+	copy(maskedNullBitmapBytes, nullBitmapBytes)
+	for i := 0; i < field.Len(); i++ {
+		if !a.IsValid(i) {
+			bitutil.ClearBit(maskedNullBitmapBytes, i)
+		}
+	}
+	data := NewSliceData(field.Data(), 0, int64(field.Len()))
+	bufs := make([]*memory.Buffer, len(data.buffers))
+	copy(bufs, data.buffers)
+	bufs[0].Release()
+	bufs[0] = memory.NewBufferBytes(maskedNullBitmapBytes)
+	data.buffers = bufs
+	maskedField := MakeFromData(data)
+	data.Release()
+	return maskedField
 }
 
 func (a *Struct) setData(data *Data) {
@@ -81,8 +97,8 @@ func (a *Struct) setData(data *Data) {
 	for i, child := range data.childData {
 		if data.offset != 0 || child.length != data.length {
 			sub := NewSliceData(child, int64(data.offset), int64(data.offset+data.length))
-			defer sub.Release()
 			a.fields[i] = MakeFromData(sub)
+			sub.Release()
 		} else {
 			a.fields[i] = MakeFromData(child)
 		}

--- a/go/arrow/array/struct_test.go
+++ b/go/arrow/array/struct_test.go
@@ -309,8 +309,9 @@ func TestStructArraySlice(t *testing.T) {
 	defer pool.AssertSize(t, 0)
 
 	var (
-		f1s = []float64{1.1, 1.2, 1.3, 1.4}
-		f2s = []int32{1, 2, 3, 4}
+		f1s    = []float64{1.1, 1.2, 1.3, 1.4}
+		f2s    = []int32{1, 2, 3, 4}
+		valids = []bool{true, true, true, true}
 
 		fields = []arrow.Field{
 			{Name: "f1", Type: arrow.PrimitiveTypes.Float64},
@@ -331,7 +332,7 @@ func TestStructArraySlice(t *testing.T) {
 	}
 
 	for i := range f1s {
-		sb.Append(true)
+		sb.Append(valids[i])
 		switch i {
 		case 1:
 			f1b.AppendNull()
@@ -354,6 +355,54 @@ func TestStructArraySlice(t *testing.T) {
 
 	want := "{[1.3 1.4] [(null) 4]}"
 	got := arrSlice.String()
+	if got != want {
+		t.Fatalf("invalid string representation:\ngot = %q\nwant= %q", got, want)
+	}
+}
+
+func TestStructArrayNullBitmap(t *testing.T) {
+	pool := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer pool.AssertSize(t, 0)
+
+	var (
+		f1s    = []float64{1.1, 1.2, 1.3, 1.4}
+		f2s    = []int32{1, 2, 3, 4}
+		valids = []bool{true, true, true, false}
+
+		fields = []arrow.Field{
+			{Name: "f1", Type: arrow.PrimitiveTypes.Float64},
+			{Name: "f2", Type: arrow.PrimitiveTypes.Int32},
+		}
+		dtype = arrow.StructOf(fields...)
+	)
+
+	sb := array.NewStructBuilder(pool, dtype)
+	defer sb.Release()
+
+	f1b := sb.FieldBuilder(0).(*array.Float64Builder)
+
+	f2b := sb.FieldBuilder(1).(*array.Int32Builder)
+
+	if got, want := sb.NumField(), 2; got != want {
+		t.Fatalf("got=%d, want=%d", got, want)
+	}
+
+	sb.AppendValues(valids)
+	for i := range f1s {
+		f1b.Append(f1s[i])
+		switch i {
+		case 1:
+			f2b.AppendNull()
+		default:
+			f2b.Append(f2s[i])
+		}
+	}
+
+	arr := sb.NewArray().(*array.Struct)
+	defer arr.Release()
+
+	want := "{[1.1 1.2 1.3 (null)] [1 (null) 3 (null)]}"
+	got := arr.String()
 	if got != want {
 		t.Fatalf("invalid string representation:\ngot = %q\nwant= %q", got, want)
 	}

--- a/go/arrow/internal/arrdata/arrdata.go
+++ b/go/arrow/internal/arrdata/arrdata.go
@@ -188,9 +188,6 @@ func makeStructsRecords() []array.Record {
 	dtype := arrow.StructOf(fields...)
 	schema := arrow.NewSchema([]arrow.Field{{Name: "struct_nullable", Type: dtype, Nullable: true}}, nil)
 
-	bldr := array.NewStructBuilder(mem, dtype)
-	defer bldr.Release()
-
 	mask := []bool{true, false, false, true, true, true, false, true}
 	chunks := [][]array.Interface{
 		[]array.Interface{
@@ -1042,8 +1039,8 @@ func structOf(mem memory.Allocator, dtype *arrow.StructType, fields [][]array.In
 		}
 	}
 
-	for i, valid := range valids {
-		bldr.Append(valid)
+	for i := range fields {
+		bldr.AppendValues(valids)
 		for j := range dtype.Fields() {
 			fbldr := bldr.FieldBuilder(j)
 			buildArray(fbldr, fields[i][j])

--- a/go/arrow/ipc/cmd/arrow-cat/main_test.go
+++ b/go/arrow/ipc/cmd/arrow-cat/main_test.go
@@ -78,9 +78,9 @@ record 3...
 		{
 			name: "structs",
 			want: `record 1...
-  col[0] "struct_nullable": {[-1 (null) (null) -4 -5 (null) -11 (null) (null) -14 -15 -21 (null) (null) -24 -25 -31 (null) (null) -34 -35 -41 (null) (null) -44 -45] ["111" (null) (null) "444" "555" (null) "1111" (null) (null) "1444" "1555" "2111" (null) (null) "2444" "2555" "3111" (null) (null) "3444" "3555" "4111" (null) (null) "4444" "4555"]}
+  col[0] "struct_nullable": {[-1 (null) (null) -4 -5 -11 (null) (null) -14 -15 -21 (null) (null) -24 -25 -31 (null) (null) -34 -35 -41 (null) (null) -44 -45] ["111" (null) (null) "444" "555" "1111" (null) (null) "1444" "1555" "2111" (null) (null) "2444" "2555" "3111" (null) (null) "3444" "3555" "4111" (null) (null) "4444" "4555"]}
 record 2...
-  col[0] "struct_nullable": {[1 (null) (null) 4 5 (null) 11 (null) (null) 14 15 (null) 21 (null) (null) 24 25 31 (null) (null) 34 35 41 (null) (null) 44 45] ["-111" (null) (null) "-444" "-555" (null) "-1111" (null) (null) "-1444" "-1555" (null) "-2111" (null) (null) "-2444" "-2555" "-3111" (null) (null) "-3444" "-3555" "-4111" (null) (null) "-4444" "-4555"]}
+  col[0] "struct_nullable": {[1 (null) (null) 4 5 11 (null) (null) 14 15 21 (null) (null) 24 25 31 (null) (null) 34 35 41 (null) (null) 44 45] ["-111" (null) (null) "-444" "-555" "-1111" (null) (null) "-1444" "-1555" "-2111" (null) (null) "-2444" "-2555" "-3111" (null) (null) "-3444" "-3555" "-4111" (null) (null) "-4444" "-4555"]}
 `,
 		},
 		{
@@ -315,18 +315,18 @@ record 3/3...
 			stream: true,
 			name:   "structs",
 			want: `record 1...
-  col[0] "struct_nullable": {[-1 (null) (null) -4 -5 (null) -11 (null) (null) -14 -15 -21 (null) (null) -24 -25 -31 (null) (null) -34 -35 -41 (null) (null) -44 -45] ["111" (null) (null) "444" "555" (null) "1111" (null) (null) "1444" "1555" "2111" (null) (null) "2444" "2555" "3111" (null) (null) "3444" "3555" "4111" (null) (null) "4444" "4555"]}
+  col[0] "struct_nullable": {[-1 (null) (null) -4 -5 -11 (null) (null) -14 -15 -21 (null) (null) -24 -25 -31 (null) (null) -34 -35 -41 (null) (null) -44 -45] ["111" (null) (null) "444" "555" "1111" (null) (null) "1444" "1555" "2111" (null) (null) "2444" "2555" "3111" (null) (null) "3444" "3555" "4111" (null) (null) "4444" "4555"]}
 record 2...
-  col[0] "struct_nullable": {[1 (null) (null) 4 5 (null) 11 (null) (null) 14 15 (null) 21 (null) (null) 24 25 31 (null) (null) 34 35 41 (null) (null) 44 45] ["-111" (null) (null) "-444" "-555" (null) "-1111" (null) (null) "-1444" "-1555" (null) "-2111" (null) (null) "-2444" "-2555" "-3111" (null) (null) "-3444" "-3555" "-4111" (null) (null) "-4444" "-4555"]}
+  col[0] "struct_nullable": {[1 (null) (null) 4 5 11 (null) (null) 14 15 21 (null) (null) 24 25 31 (null) (null) 34 35 41 (null) (null) 44 45] ["-111" (null) (null) "-444" "-555" "-1111" (null) (null) "-1444" "-1555" "-2111" (null) (null) "-2444" "-2555" "-3111" (null) (null) "-3444" "-3555" "-4111" (null) (null) "-4444" "-4555"]}
 `,
 		},
 		{
 			name: "structs",
 			want: `version: V4
 record 1/2...
-  col[0] "struct_nullable": {[-1 (null) (null) -4 -5 (null) -11 (null) (null) -14 -15 -21 (null) (null) -24 -25 -31 (null) (null) -34 -35 -41 (null) (null) -44 -45] ["111" (null) (null) "444" "555" (null) "1111" (null) (null) "1444" "1555" "2111" (null) (null) "2444" "2555" "3111" (null) (null) "3444" "3555" "4111" (null) (null) "4444" "4555"]}
+  col[0] "struct_nullable": {[-1 (null) (null) -4 -5 -11 (null) (null) -14 -15 -21 (null) (null) -24 -25 -31 (null) (null) -34 -35 -41 (null) (null) -44 -45] ["111" (null) (null) "444" "555" "1111" (null) (null) "1444" "1555" "2111" (null) (null) "2444" "2555" "3111" (null) (null) "3444" "3555" "4111" (null) (null) "4444" "4555"]}
 record 2/2...
-  col[0] "struct_nullable": {[1 (null) (null) 4 5 (null) 11 (null) (null) 14 15 (null) 21 (null) (null) 24 25 31 (null) (null) 34 35 41 (null) (null) 44 45] ["-111" (null) (null) "-444" "-555" (null) "-1111" (null) (null) "-1444" "-1555" (null) "-2111" (null) (null) "-2444" "-2555" "-3111" (null) (null) "-3444" "-3555" "-4111" (null) (null) "-4444" "-4555"]}
+  col[0] "struct_nullable": {[1 (null) (null) 4 5 11 (null) (null) 14 15 21 (null) (null) 24 25 31 (null) (null) 34 35 41 (null) (null) 44 45] ["-111" (null) (null) "-444" "-555" "-1111" (null) (null) "-1444" "-1555" "-2111" (null) (null) "-2444" "-2555" "-3111" (null) (null) "-3444" "-3555" "-4111" (null) (null) "-4444" "-4555"]}
 `,
 		},
 		{


### PR DESCRIPTION
Before this fix, calling `String()` on `Struct` would not take into account the validity bitmap of the struct when printing the child fields.

From the documentation:

> While a struct does not have physical storage for each of its semantic slots (i.e. each scalar C-like struct), an entire struct slot can be set to null via the validity bitmap. Any of the child field arrays can have null values according to their respective independent validity bitmaps. This implies that for a particular struct slot the validity bitmap for the struct array might indicate a null slot when one or more of its child arrays has a non-null value in their corresponding slot. When reading the struct array the parent validity bitmap takes priority.